### PR TITLE
Replace psych .load with .unsafe_load

### DIFF
--- a/lib/asetus/adapter/yaml.rb
+++ b/lib/asetus/adapter/yaml.rb
@@ -18,7 +18,7 @@ class Asetus
 
         def from yaml
           require 'yaml'
-          ::YAML.load yaml
+          ::YAML.unsafe_load yaml
         end
       end
     end


### PR DESCRIPTION
Since psych 4.x .load was changed to behave like .safe_load with Symbol class permitted by default.

Since asetus is designed to parse trusted data, using .unsafe_load is safe.